### PR TITLE
Upgrade SQLFluff

### DIFF
--- a/.github/workflows/annotate-modified-SQL.yml
+++ b/.github/workflows/annotate-modified-SQL.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install SQLFluff
-        run: "pip install sqlfluff~=2.0.0" # i.e. the latest version - upgrade as necessary
+        run: "pip install sqlfluff~=2.3.5"
 
       - name: Find changed SQL files # they appear as ${{ steps.files.outputs }} in the next step (a space-separated list of filepaths)
         id: files

--- a/.github/workflows/annotate-modified-SQL.yml
+++ b/.github/workflows/annotate-modified-SQL.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install SQLFluff
-        run: "pip install sqlfluff==1.4.5" # i.e. the latest version - upgrade as necessary
+        run: "pip install sqlfluff~=2.0.0" # i.e. the latest version - upgrade as necessary
 
       - name: Find changed SQL files # they appear as ${{ steps.files.outputs }} in the next step (a space-separated list of filepaths)
         id: files

--- a/.github/workflows/annotate-modified-SQL.yml
+++ b/.github/workflows/annotate-modified-SQL.yml
@@ -15,10 +15,9 @@ jobs:
       - uses: "actions/checkout@v3"
 
       - run: | # download the .sqlfluff config file from this repo to the repo the action is being run in
-          curl -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-          -H 'Accept: application/vnd.github.v4.raw' \
+          curl \
           -O \
-          -L https://api.github.com/repos/Toronto-Big-Data-Innovation-Team/.github/contents/.sqlfluff
+          -L https://raw.githubusercontent.com/Toronto-Big-Data-Innovation-Team/.github/sqlfluff-upgrade/.sqlfluff
 
       - uses: "actions/setup-python@v4"
         with:

--- a/.github/workflows/annotate-modified-SQL.yml
+++ b/.github/workflows/annotate-modified-SQL.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.9"
 
       - name: Install SQLFluff
-        run: "pip install sqlfluff~=2.3.5"
+        run: "pip install sqlfluff~=3.0.0a4"
 
       - name: Find changed SQL files # they appear as ${{ steps.files.outputs }} in the next step (a space-separated list of filepaths)
         id: files

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,19 +1,20 @@
 [sqlfluff]
 dialect = postgres
-exclude_rules = L009, L030, L031, L032, L051, L055
-warnings = L001, L005, L006, L008, L016, L023, L050
+max_line_length = 100
+exclude_rules = layout.end-of-file, capitalisation.functions, aliasing.forbid, structure.using, ambiguous.join, convention.left_join
+warnings = layout.spacing, layout.long_lines, layout.start_of_file
 
-[sqlfluff:rules]
+[sqlfluff:indentation]
 tab_space_size = 4
 indent_unit = space
-max_line_length = 100
+
 aliasing = explicit
 
-[sqlfluff:rules:L010]
+[sqlfluff:rules:capitalisation.keywords]
 capitalisation_policy = upper
 
-[sqlfluff:rules:L040]
+[sqlfluff:rules:capitalisation.literals]
 capitalisation_policy = upper
 
-[sqlfluff:rules:L063]
+[sqlfluff:rules:capitalisation.types]
 extended_capitalisation_policy = lower

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,7 +1,7 @@
 [sqlfluff]
 dialect = postgres
 max_line_length = 100
-exclude_rules = layout.end-of-file, capitalisation.functions, aliasing.forbid, structure.using, ambiguous.join, convention.left_join
+exclude_rules = layout.end-of-file, capitalisation.functions, aliasing.forbid, structure.using, ambiguous.join, convention.left_join, structure.column_order
 warnings = layout.spacing, layout.long_lines, layout.start_of_file
 
 [sqlfluff:indentation]

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -3,7 +3,7 @@ dialect = postgres
 
 max_line_length = 100
 exclude_rules = layout.end-of-file, capitalisation.functions, aliasing.forbid, structure.using, ambiguous.join, convention.left_join, structure.column_order
-warnings = layout.spacing, layout.long_lines, layout.start_of_file
+warnings = LT01, LT05, LT13
 
 [sqlfluff:indentation]
 tab_space_size = 4


### PR DESCRIPTION
Resolves #2

This is currently on hold while some issues with the new version are ironed out. For now we can stick with v1.4.5. 

Issues with v2.x are being documented in comments below. As new features are added, it may make sense to make the switch even if all these particular issues don't get resolved. 